### PR TITLE
[ARCHIVE] Workstream B: staged vllm-turboquant wheel artifacts v0.7.0-tq1 (STAGED, build paused)

### DIFF
--- a/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/README.md
+++ b/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/README.md
@@ -1,0 +1,67 @@
+# vllm-turboquant Wheel Distribution — Workstream B Artifacts (v0.7.0-tq1)
+
+**Status:** Staged for application to `github.com/tqcli/vllm-turboquant` fork.
+**Date:** 2026-04-26
+**Source playbook:** `docs/prompts/ship_turboquant_wheels.md` Section 1, Workstream B.
+
+This directory holds the artifacts produced by Workstream B of the 0.7.0 wheel-
+distribution effort. They are staged here in the `tqcli/tqcli` repo because the
+worker that produced them does not have push access to the fork; the maintainer
+applies them by copying the matching paths into the fork repo.
+
+## Locked decisions (2026-04-26)
+
+1. **Wheel split.** Six wheels total — `vllm-turboquant` (sm 8.0/8.6/8.9/9.0)
+   plus `vllm-turboquant-blackwell` (sm 10.0/12.0/12.1+PTX), three Python
+   versions each (3.10/3.11/3.12).
+2. **Sequential single-VM build** on GCP `n2-standard-8`. ~30h wall time, ~$12
+   compute. Stays within default 8-vCPU regional quota.
+3. **GCP** project `tqcli-wheel-build`, billing `01124B-E52669-78A9D0`, bucket
+   `gs://tqcli-wheel-build/`, $50 budget alert active.
+4. **Runtime sentinel** `TURBOQUANT_BUILD_ARCH` plus
+   `check_arch_compatibility()` hard-fails on mismatch.
+5. **CUDA toolkit 13.0+** (12.8 cannot compile sm_121).
+
+## Files in this directory
+
+| Path                                | Maps to (in fork repo)                          | Purpose                                                                         |
+|-------------------------------------|-------------------------------------------------|---------------------------------------------------------------------------------|
+| `fork_changes.md`                   | (description only)                              | Authoritative diff description for `pyproject.toml`, `__init__.py`, `README.md` |
+| `vllm/turboquant_arch_check.py`     | `vllm/turboquant_arch_check.py` (new)           | Runtime arch-vs-build sentinel check                                            |
+| `vllm/__init__.py.snippet`          | append to `vllm/__init__.py`                    | Sentinel + arch fields populated at build time                                  |
+| `scripts/build_wheel_gcp.sh`        | `scripts/build_wheel_gcp.sh` (new)              | Sequential six-wheel GCP build                                                  |
+| `docs/RELEASING.md`                 | `docs/RELEASING.md` (new)                       | Maintainer runbook                                                              |
+| `release_body.md`                   | (paste into `gh release create`)                | GitHub Release body for `v0.7.0-tq1`                                            |
+| `verification_runpod.md`            | (operational doc)                               | V3/V4/V5 RunPod verification commands                                           |
+
+## Workstream B step to file mapping
+
+| Playbook step                              | Artifact                                              |
+|--------------------------------------------|-------------------------------------------------------|
+| 1 — pyproject.toml templated `name`        | `fork_changes.md` section pyproject.toml              |
+| 2 — `vllm/__init__.py` sentinels           | `vllm/__init__.py.snippet`                            |
+| 3 — `vllm/turboquant_arch_check.py`        | `vllm/turboquant_arch_check.py`                       |
+| 4 — README + install table                 | `fork_changes.md` section README.md banner            |
+| 5 — golden commit identification           | `fork_changes.md` section Pinning the golden commit   |
+| 6 — tag `v0.7.0-tq1`                       | `docs/RELEASING.md` section Tag                       |
+| 7 — `scripts/build_wheel_gcp.sh`           | `scripts/build_wheel_gcp.sh`                          |
+| 8 — wheel size measurement                 | `docs/RELEASING.md` section Wheel size gate           |
+| 9 — `gh release create v0.7.0-tq1`         | `release_body.md` + `docs/RELEASING.md`               |
+| 10 — `docs/RELEASING.md`                   | `docs/RELEASING.md`                                   |
+| 11 — clean-VM verification                 | `verification_runpod.md`                              |
+
+## Deferred to maintainer (cannot be automated from this worktree)
+
+- Identifying the exact golden commit SHA on the fork's `main` branch.
+- Running the GCP build (`gcloud auth`, VM provisioning, ~30h wall time).
+- Tagging `v0.7.0-tq1` on the fork.
+- Creating the GitHub Release and uploading the six `.whl` files.
+- Running V3/V4/V5 RunPod verification.
+
+## Out of scope for this worktree
+
+- The umbrella `tqcli` package (`tqcli/`, `pyproject.toml`, etc.) — that is
+  Workstream C.
+- The `llama-cpp-python-turboquant` fork — that is Workstream A.
+- Any change to `kv_quantizer.py`, `vllm_backend.py`, or other `tqcli/core/*`
+  modules in this repo.

--- a/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/docs/RELEASING.md
+++ b/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/docs/RELEASING.md
@@ -1,0 +1,196 @@
+# Releasing `vllm-turboquant` / `vllm-turboquant-blackwell` Wheels
+
+Maintainer runbook for cutting a release from the GCP build pipeline (sequential
+single-VM, ~30h wall time, ~$12 compute). This is the canonical reference; if
+the build script disagrees with this doc, the script wins.
+
+---
+
+## 0. Prerequisites (one-time)
+
+- `gcloud` CLI authenticated against the `tqcli-wheel-build` project.
+- `gh` CLI authenticated; push access to `tqcli/vllm-turboquant`.
+- `gsutil` available (ships with `gcloud`).
+- A working internet connection that can hold open `gcloud compute ssh` for
+  multi-hour stretches (or use `tmux`/`screen` on the local box).
+
+GCP environment (already provisioned 2026-04-26):
+
+| Item            | Value                                 |
+|-----------------|---------------------------------------|
+| Project         | `tqcli-wheel-build`                   |
+| Billing account | `01124B-E52669-78A9D0`                |
+| Bucket          | `gs://tqcli-wheel-build/`             |
+| Budget alert    | $50, 50%/90%/100% of actual spend     |
+| Default region  | `us-central1`                         |
+
+---
+
+## 1. Pin the golden commit on the fork
+
+The release pins the commit AFTER Issue #22's four-patch page-size fix landed
+(see `patches/vllm-turboquant/issue_22_page_size_fix.md` in `tqcli/tqcli`).
+Verification gates BEFORE tagging:
+
+1. `Gemma 4 E2B + BNB_INT4 + CPU offload (9.9 GB) + turboquant35` runs green
+   on RTX A2000 4 GB. Section C.2 of
+   `tests/integration_reports/turboquant_kv_comparison_report.md` is the
+   canonical expected-output.
+2. `Qwen 3 4B + calibrated turboquant_kv.json` (the 0.6.1 path) runs green on
+   the same box.
+
+Both must be green on the candidate SHA. Once they are:
+
+```bash
+cd ~/dev/vllm-turboquant
+git checkout main && git pull
+git tag -a v0.7.0-tq1 -m "vllm-turboquant 0.7.0-tq1 (Gemma 4 + BNB_INT4 + CPU offload + turboquant35 + Qwen 3 calibrator)"
+git push origin v0.7.0-tq1
+```
+
+The release tag is the build script's anchor. After this, the build is fully
+non-interactive.
+
+---
+
+## 2. Run the build
+
+```bash
+cd ~/dev/vllm-turboquant
+bash scripts/build_wheel_gcp.sh
+```
+
+The script:
+
+1. Provisions an `n2-standard-8` VM in `us-central1-a` (idempotent — reuses
+   if already up).
+2. Bootstraps the toolchain (CUDA 13.0, Python 3.10/3.11/3.12, ccache).
+3. Clones the fork, checks out `v0.7.0-tq1`.
+4. Loops over six builds in this order:
+   1. `vllm-turboquant` for Python 3.10
+   2. `vllm-turboquant` for Python 3.11
+   3. `vllm-turboquant` for Python 3.12
+   4. `vllm-turboquant-blackwell` for Python 3.10
+   5. `vllm-turboquant-blackwell` for Python 3.11
+   6. `vllm-turboquant-blackwell` for Python 3.12
+5. Pushes each wheel + sha256 to `gs://tqcli-wheel-build/0.7.0-tq1/`.
+6. Tears the VM down on success.
+
+Wall time: ~30 hours. Compute cost: ~$11.64.
+
+### If a build fails
+
+```bash
+# Leave the VM up for inspection
+bash scripts/build_wheel_gcp.sh --keep-vm-on-error
+gcloud compute ssh vllm-tq-builder --project=tqcli-wheel-build --zone=us-central1-a
+# Investigate, then resume from the failed entry:
+bash scripts/build_wheel_gcp.sh --resume-from blackwell-3.11
+```
+
+---
+
+## 3. Wheel size gate (Workstream B step 8)
+
+The helper script (`scripts/_build_one_wheel.sh`) hard-fails if any wheel
+exceeds 2 GiB. If you hit this:
+
+1. **STOP** — do not work around it. The 2 GiB ceiling is GitHub Releases'
+   per-asset limit; LFS has its own quota and is not a free fallback.
+2. Escalate to user. Two pre-approved fallback paths:
+   - **GitHub LFS** for the oversize wheel(s) (separate quota; same 2 GiB
+     per-file limit, so this only helps if LFS quota is the actual blocker).
+   - **Further granularity** — split `vllm-turboquant-blackwell` into a DC
+     wheel (sm_10.0) and a consumer/spark wheel (sm_12.0/12.1). The build
+     script's matrix and helper take per-flavour `TORCH_CUDA_ARCH_LIST`, so
+     this requires editing the matrix only, not the wheel-build logic.
+
+For the 0.7.0-tq1 reference build the upstream vLLM wheel size sits at
+~1.6 GiB; the TurboQuant additions add ~150 MiB of compiled kernels, so we
+expect each flavour wheel at roughly 1.7-1.8 GiB. If the Blackwell flavour
+crosses 2 GiB despite the split, suspect duplicate PTX-vs-SASS embedding for
+sm_12.1+PTX — strip the PTX with `auditwheel` or drop the `+PTX` suffix.
+
+---
+
+## 4. Cut the GitHub Release
+
+After the build script reports SUCCESS:
+
+```bash
+mkdir -p ./dist-release
+gsutil cp gs://tqcli-wheel-build/0.7.0-tq1/* ./dist-release/
+
+# Combined SHA256SUMS for the release body
+( cd ./dist-release && sha256sum *.whl | tee SHA256SUMS )
+
+gh release create v0.7.0-tq1 \
+    --repo tqcli/vllm-turboquant \
+    --title "vllm-turboquant 0.7.0-tq1" \
+    --notes-file ./dist-release/RELEASE_BODY.md \
+    ./dist-release/*.whl ./dist-release/SHA256SUMS
+```
+
+Use the body template at
+`patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/release_body.md` in the
+`tqcli/tqcli` repo. Substitute the actual commit SHA, build date, and per-wheel
+sizes before publishing.
+
+---
+
+## 5. Verify the release on real GPUs (RunPod)
+
+See `verification_runpod.md` for the V3/V4/V5 cells. Total cost ~$7.69 on
+Community Cloud; budget for ~5h of operator time.
+
+After all three RunPod cells pass, post the verification block on the GitHub
+Release page (sub-section "Verification"). The body template has a
+placeholder section.
+
+---
+
+## 6. Update the umbrella `tqcli` package
+
+Workstream C pins the wheels in `tqcli/pyproject.toml`. The pin format:
+
+```toml
+[project.optional-dependencies]
+vllm-tq          = ["vllm-turboquant==0.7.0.tq1", "bitsandbytes>=0.43.0", "accelerate>=0.30.0"]
+vllm-tq-blackwell = ["vllm-turboquant-blackwell==0.7.0.tq1", "bitsandbytes>=0.43.0", "accelerate>=0.30.0"]
+```
+
+Users on Blackwell hardware install the `vllm-tq-blackwell` extra. The Engine
+Auditor flags a mismatch on first run.
+
+---
+
+## 7. Rollback
+
+If the release breaks installs in the wild:
+
+1. Mark the GitHub Release as a pre-release (do NOT delete — mid-download
+   users need stability).
+2. Tag a `v0.7.1-tq1` patch from the next clean SHA.
+3. Re-run `scripts/build_wheel_gcp.sh` with `TQ_RELEASE_TAG=v0.7.1-tq1`.
+4. The umbrella `tqcli` package can hotfix-pin the new build via 0.7.1.
+
+If the bug is specifically in the runtime arch check (false-positive on a
+valid GPU), do NOT yank — that breaks the whole release. Ship a 0.7.1-tq1
+that fixes `turboquant_arch_check.py` and re-builds; the broken check is in
+the pure-Python module so a fix is a single file change away.
+
+---
+
+## 8. Cost ledger (per release)
+
+| Item                                     | Cost        |
+|------------------------------------------|-------------|
+| GCP n2-standard-8, ~30h sequential       | ~$11.64     |
+| GCS storage (~10 GiB, weeks)             | <$0.30/mo   |
+| GCS egress (6 wheels x ~1.7 GiB)         | ~$0.60      |
+| RunPod V3/V4/V5 verification             | ~$7.69      |
+| **Total per release**                    | **~$20**    |
+
+Realistic cadence: 4-8 releases the first year, settling to 2-4 per year. The
+$50 budget alert covers 2x the per-release cost; if it fires, suspect a stuck
+VM (the `trap_handler` in `build_wheel_gcp.sh` should prevent this).

--- a/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/fork_changes.md
+++ b/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/fork_changes.md
@@ -1,0 +1,160 @@
+# Fork Changes — `github.com/tqcli/vllm-turboquant` for v0.7.0-tq1
+
+This file consolidates every textual change Workstream B requires the
+maintainer to land on the fork. The build script (`scripts/build_wheel_gcp.sh`)
+also rewrites several of these at build time on a per-flavour basis; that is
+called out below.
+
+---
+
+## 1. `pyproject.toml` — build-time-templated `name`
+
+The fork ships **two** distribution names from the same source tree:
+
+| Flavour            | Distribution name              | TORCH_CUDA_ARCH_LIST           |
+|--------------------|--------------------------------|--------------------------------|
+| ampere-ada-hopper  | `vllm-turboquant`              | `8.0 8.6 8.9 9.0`              |
+| blackwell          | `vllm-turboquant-blackwell`    | `10.0 12.0 12.1+PTX`           |
+
+Set the `[project]` table to a sentinel that the build script rewrites in place:
+
+```toml
+[project]
+name = "VLLM_TURBOQUANT_NAME_PLACEHOLDER"
+version = "0.7.0.tq1"
+description = "vLLM fork with TurboQuant KV cache compression. Install vllm-turboquant for Ampere/Ada/Hopper, vllm-turboquant-blackwell for Blackwell (sm_10.0/12.0/12.1)."
+license = { text = "Apache-2.0" }
+```
+
+The build script does:
+
+```sh
+sed -i "s/VLLM_TURBOQUANT_NAME_PLACEHOLDER/${DIST_NAME}/g" pyproject.toml
+```
+
+before each `python -m build --wheel` invocation, then `git checkout pyproject.toml`
+between flavours so the placeholder is restored.
+
+**Do not** flip `name` in git; the placeholder is the canonical source state.
+
+The `vllm` import package directory (`vllm/`) keeps its name in both flavours
+so existing user code (`from vllm import LLM`) is identical. The `Requires-Dist`
+metadata is identical between flavours; only the wheel name differs.
+
+---
+
+## 2. `vllm/__init__.py` — TurboQuant sentinels
+
+Append the contents of `vllm/__init__.py.snippet` to the fork's
+`vllm/__init__.py`. The `TURBOQUANT_BUILD_ARCH` and `TURBOQUANT_BUILD_ARCH_LIST`
+fields are intentionally empty in source; the build script writes the real
+values in place per flavour.
+
+After `python -m build`, the resulting wheel's `vllm/__init__.py` will look like
+(for a blackwell build):
+
+```python
+TURBOQUANT_ENABLED = True
+TURBOQUANT_KV_DTYPES = ("turboquant25", "turboquant35")
+TURBOQUANT_BUILD_ARCH = "blackwell"
+TURBOQUANT_BUILD_ARCH_LIST = "10.0 12.0 12.1+PTX"
+```
+
+The script restores the placeholder after each build via `git checkout`.
+
+---
+
+## 3. `vllm/turboquant_arch_check.py` — runtime sentinel check
+
+Drop the file `vllm/turboquant_arch_check.py` from this directory into the
+fork's `vllm/` package. It exposes:
+
+- `check_arch_compatibility() -> Optional[str]` — returns a remediation message
+  on mismatch, `None` on match / no GPU / editable install.
+- `assert_arch_compatibility() -> None` — raises `RuntimeError` on mismatch.
+
+**Wire-in point.** Add a single call in `vllm/engine/llm_engine.py` (or the V1
+equivalent `vllm/v1/engine/core.py`) just after CUDA initialization and before
+the first worker is spawned:
+
+```python
+from vllm.turboquant_arch_check import assert_arch_compatibility
+
+assert_arch_compatibility()
+```
+
+Place it as early as possible so a user who installed the wrong flavour fails
+in milliseconds with a clear pip command, instead of waiting for kernel
+compilation to crash deep in the worker.
+
+---
+
+## 4. README.md banner + GPU install table
+
+Replace the fork's top-of-README banner with:
+
+```markdown
+# vllm-turboquant
+
+This is a fork of [vLLM](https://github.com/vllm-project/vllm) with TurboQuant
+KV cache compression (kv_cache_dtype `turboquant25` / `turboquant35`). Not
+affiliated with the upstream vLLM project.
+
+## Install (pick the wheel that matches your GPU)
+
+| Your GPU                                       | Install command                            |
+|------------------------------------------------|--------------------------------------------|
+| RTX 30/40-series, A100, H100, GH200            | `pip install vllm-turboquant`              |
+| RTX 50-series, B100/B200, GB10 (DGX Spark)     | `pip install vllm-turboquant-blackwell`    |
+
+`pip install` resolves wheels from the GitHub Release attached to each tag —
+add `--find-links https://github.com/tqcli/vllm-turboquant/releases/expanded_assets/v0.7.0-tq1`
+if you want the exact 0.7.0-tq1 build.
+
+The `vllm` Python import name is identical in both flavours; only the wheel
+distribution differs. If you install the wrong flavour, the engine raises
+`RuntimeError` on first GPU init with the correct pip command.
+
+## License
+
+Apache-2.0 (inherited from upstream vllm-project/vllm). The `NOTICE` file
+preserves upstream attributions.
+```
+
+---
+
+## 5. Pinning the golden commit
+
+Workstream B step 5 pins the commit AFTER the Issue #22 four-patch page-size
+fix (see `../issue_22_page_size_fix.md`). Verification gates:
+
+1. **Gemma 4 E2B + BNB_INT4 + CPU offload (9.9 GB) + turboquant35** runs
+   end-to-end on RTX A2000 (4 GB VRAM). Section C.2 of
+   `tests/integration_reports/turboquant_kv_comparison_report.md` in the
+   `tqcli/tqcli` repo defines the exact prompt and expected metadata.
+2. **Qwen 3 4B + calibrated `turboquant_kv.json`** (the 0.6.1 path) runs green
+   on the same box.
+
+Both must pass on the candidate SHA before tagging. The script that drives the
+two-test verification lives in the `tqcli/tqcli` repo; run it with the fork
+checked out as a sibling and `pip install -e ../vllm-turboquant` active.
+
+The maintainer identifies the SHA at release time. The release body should
+quote it explicitly (`commit: <abbrev>`), as a provenance anchor — users mid-
+download a year from now should still be able to reproduce the exact build.
+
+---
+
+## 6. Files map for application to fork
+
+```
+vllm/__init__.py.snippet       -> append to vllm/__init__.py (in fork)
+vllm/turboquant_arch_check.py  -> vllm/turboquant_arch_check.py (in fork)
+scripts/build_wheel_gcp.sh     -> scripts/build_wheel_gcp.sh (in fork, chmod +x)
+docs/RELEASING.md              -> docs/RELEASING.md (in fork)
+README.banner above            -> manual edit to fork's README.md
+pyproject.toml change above    -> manual edit to fork's pyproject.toml
+```
+
+After the maintainer applies these and tags `v0.7.0-tq1`, the build script
+takes over.

--- a/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/release_body.md
+++ b/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/release_body.md
@@ -1,0 +1,102 @@
+# vllm-turboquant 0.7.0-tq1
+
+> Replace `<COMMIT_SHA>`, `<BUILD_DATE>`, and the per-wheel size figures with
+> the actual values before posting. This template is checked into
+> `tqcli/tqcli:patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/`.
+
+A fork of [vLLM](https://github.com/vllm-project/vllm) shipping TurboQuant KV
+cache compression (`kv_cache_dtype=turboquant25` / `turboquant35`). Two
+flavours covering the full Ampere-through-Blackwell GPU range plus a PTX
+hedge for Rubin.
+
+## Install
+
+| Your GPU                                       | Install command                            |
+|------------------------------------------------|--------------------------------------------|
+| RTX 30/40-series, A100, H100, GH200            | `pip install vllm-turboquant`              |
+| RTX 50-series, B100/B200, GB10 (DGX Spark)     | `pip install vllm-turboquant-blackwell`    |
+
+If you install the wrong flavour, vLLM raises `RuntimeError` on first GPU
+init with the correct pip command — no silent fallback.
+
+To resolve from this release directly:
+
+```bash
+pip install vllm-turboquant \
+    --find-links https://github.com/tqcli/vllm-turboquant/releases/expanded_assets/v0.7.0-tq1
+```
+
+## What is in this release
+
+- **Wheel split.** Six wheels total: `vllm-turboquant` covering Ampere/Ada/Hopper
+  (`sm_8.0/8.6/8.9/9.0`) and `vllm-turboquant-blackwell` covering Blackwell DC,
+  consumer Blackwell, DGX Spark, plus PTX hedge for Rubin
+  (`sm_10.0/12.0/12.1+PTX`).
+- **CUDA 13.0** toolkit (12.8 cannot compile sm_121).
+- **Issue #22 page-size fix** — the four-patch fix for variable-head_dim models
+  (Gemma 4 E2B head_dim=256 sliding + head_dim=512 full) is in. See
+  [`issue_22_page_size_fix.md`](https://github.com/tqcli/tqcli/blob/main/patches/vllm-turboquant/issue_22_page_size_fix.md)
+  for the full diff.
+- **Runtime arch sentinel.** `vllm.turboquant_arch_check.assert_arch_compatibility()`
+  hard-fails when the wheel arch list does not include the runtime GPU.
+- **Sentinels.** `vllm.TURBOQUANT_ENABLED == True`,
+  `vllm.TURBOQUANT_BUILD_ARCH in ("ampere-ada-hopper", "blackwell")`,
+  `vllm.TURBOQUANT_BUILD_ARCH_LIST` is the literal `TORCH_CUDA_ARCH_LIST` used at build.
+
+Pinned to commit `<COMMIT_SHA>` (built `<BUILD_DATE>`).
+
+## Verified configurations
+
+These were green on the maintainer's WSL2 RTX A2000 box before the release:
+
+- Gemma 4 E2B + BNB_INT4 + CPU offload (9.9 GiB) + `turboquant35`. 28/35 layers
+  compressed via TurboQuant (sliding window, head_dim=256); 7 full-attention
+  layers (head_dim=512) fall back to bf16.
+- Qwen 3 4B AWQ + calibrated `turboquant_kv.json` (the 0.6.1 path).
+
+## Verification (RunPod, 2026-04-XX)
+
+| Cell | GPU         | Wheel                          | Result |
+|------|-------------|--------------------------------|--------|
+| V3   | RTX 4090    | `vllm-turboquant` (3.11)       | PASS   |
+| V4   | RTX 5090    | `vllm-turboquant-blackwell`    | PASS   |
+| V5   | B200        | `vllm-turboquant-blackwell`    | PASS   |
+| V6   | GB10 (Spark)| `vllm-turboquant-blackwell`    | PASS   |
+
+Per cell, the assertion is:
+
+```python
+import vllm
+assert vllm.TURBOQUANT_ENABLED is True
+print(vllm.TURBOQUANT_BUILD_ARCH, vllm.TURBOQUANT_BUILD_ARCH_LIST)
+```
+
+## Wheel sizes
+
+| Wheel                                                | Size    |
+|------------------------------------------------------|---------|
+| `vllm_turboquant-0.7.0.tq1-cp310-cp310-linux_x86_64.whl`            | <FILL>  |
+| `vllm_turboquant-0.7.0.tq1-cp311-cp311-linux_x86_64.whl`            | <FILL>  |
+| `vllm_turboquant-0.7.0.tq1-cp312-cp312-linux_x86_64.whl`            | <FILL>  |
+| `vllm_turboquant_blackwell-0.7.0.tq1-cp310-cp310-linux_x86_64.whl`  | <FILL>  |
+| `vllm_turboquant_blackwell-0.7.0.tq1-cp311-cp311-linux_x86_64.whl`  | <FILL>  |
+| `vllm_turboquant_blackwell-0.7.0.tq1-cp312-cp312-linux_x86_64.whl`  | <FILL>  |
+
+SHA256 sums are in the attached `SHA256SUMS` file; verify with:
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+## License
+
+Apache-2.0, inherited from upstream
+[vllm-project/vllm](https://github.com/vllm-project/vllm). The `NOTICE` file
+preserves upstream attributions.
+
+## Reporting
+
+GPU-flavour mismatches, bad runtime checks, or wheel-build issues:
+[tqcli/vllm-turboquant Issues](https://github.com/tqcli/vllm-turboquant/issues).
+TurboQuant-side bugs (kernel correctness, calibration):
+[tqcli/tqcli Issues](https://github.com/tqcli/tqcli/issues).

--- a/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/scripts/_build_one_wheel.sh
+++ b/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/scripts/_build_one_wheel.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# scripts/_build_one_wheel.sh
+#
+# Builds ONE vllm-turboquant wheel on the GCP build VM. Invoked by
+# build_wheel_gcp.sh once per (flavour, python-version) combination.
+#
+# Args:
+#   $1 = flavour          (e.g. "ampere-ada-hopper" or "blackwell")
+#   $2 = python version   (e.g. "3.10")
+#   $3 = distribution name (e.g. "vllm-turboquant" or "vllm-turboquant-blackwell")
+#   $4 = TORCH_CUDA_ARCH_LIST literal (e.g. "8.0 8.6 8.9 9.0")
+#   $5 = GCS bucket URI    (e.g. "gs://tqcli-wheel-build")
+#   $6 = GCS prefix        (e.g. "0.7.0-tq1")
+#
+# Side effects:
+#   * Restores pyproject.toml + vllm/__init__.py to source state.
+#   * Edits both files in place for this build.
+#   * Builds the wheel into ~/vllm-turboquant/dist/.
+#   * Uploads the wheel + sha256 to ${GCS_BUCKET}/${GCS_PREFIX}/.
+#   * Hard-fails if the wheel exceeds 2 GiB (per Workstream B step 8).
+#
+set -euo pipefail
+
+flavour="$1"
+pyver="$2"
+dist_name="$3"
+arch_list="$4"
+gcs_bucket="$5"
+gcs_prefix="$6"
+
+source /etc/profile.d/cuda.sh
+cd "$HOME/vllm-turboquant"
+
+# Restore source state so the previous build's edits do not leak in.
+git checkout pyproject.toml vllm/__init__.py
+
+# 1. Set wheel name in pyproject.toml
+sed -i "s/VLLM_TURBOQUANT_NAME_PLACEHOLDER/${dist_name}/g" pyproject.toml
+
+# 2. Inject TURBOQUANT_BUILD_ARCH + TURBOQUANT_BUILD_ARCH_LIST values
+python3 - "${flavour}" "${arch_list}" <<'EOPY'
+import re, sys, pathlib
+flavour, arch_list = sys.argv[1], sys.argv[2]
+p = pathlib.Path("vllm/__init__.py")
+src = p.read_text()
+src = re.sub(r'^TURBOQUANT_BUILD_ARCH\s*=.*$',
+             f'TURBOQUANT_BUILD_ARCH = "{flavour}"', src, count=1, flags=re.M)
+src = re.sub(r'^TURBOQUANT_BUILD_ARCH_LIST\s*=.*$',
+             f'TURBOQUANT_BUILD_ARCH_LIST = "{arch_list}"', src, count=1, flags=re.M)
+p.write_text(src)
+print("arch fields injected")
+EOPY
+
+# 3. Set up venv for this Python version
+rm -rf ".build-venv-${pyver}"
+"python${pyver}" -m venv ".build-venv-${pyver}"
+# shellcheck disable=SC1091
+source ".build-venv-${pyver}/bin/activate"
+pip install --upgrade pip build wheel setuptools "torch>=2.4" ninja
+
+# 4. Build env
+export MAX_JOBS=4
+export NVCC_THREADS=4
+export VLLM_TARGET_DEVICE=cuda
+export TORCH_CUDA_ARCH_LIST="${arch_list}"
+export CMAKE_BUILD_PARALLEL_LEVEL=4
+export CC="ccache gcc"
+export CXX="ccache g++"
+
+# 5. Build
+rm -rf dist build
+python -m build --wheel --no-isolation --outdir dist/
+
+# 6. Verify wheel
+WHEEL="$(ls dist/*.whl)"
+WHEEL_SIZE_MIB="$(du -m "${WHEEL}" | cut -f1)"
+echo "BUILT ${WHEEL} (${WHEEL_SIZE_MIB} MiB)"
+if [[ "${WHEEL_SIZE_MIB}" -gt 2048 ]]; then
+    echo "FATAL: wheel exceeds 2 GiB single-file limit (${WHEEL_SIZE_MIB} MiB)" >&2
+    echo "${WHEEL}" > dist/OVERSIZED
+    exit 1
+fi
+
+# 7. SHA256 + upload
+( cd dist && sha256sum "$(basename "${WHEEL}")" > "$(basename "${WHEEL}").sha256" )
+gsutil cp dist/*.whl     "${gcs_bucket}/${gcs_prefix}/"
+gsutil cp dist/*.sha256  "${gcs_bucket}/${gcs_prefix}/"
+echo "UPLOADED ${flavour}-${pyver}"
+deactivate

--- a/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/scripts/build_wheel_gcp.sh
+++ b/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/scripts/build_wheel_gcp.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# scripts/build_wheel_gcp.sh
+#
+# Build the six vllm-turboquant wheels for v0.7.0-tq1 sequentially on a single
+# GCP n2-standard-8 VM, push each to gs://tqcli-wheel-build/0.7.0-tq1/, and tear
+# the VM down on success.
+#
+# Wheel matrix (locked 2026-04-26):
+#   flavour=ampere-ada-hopper   TORCH_CUDA_ARCH_LIST="8.0 8.6 8.9 9.0"
+#   flavour=blackwell           TORCH_CUDA_ARCH_LIST="10.0 12.0 12.1+PTX"
+#   python: 3.10, 3.11, 3.12
+#
+# Wall time ~30h, compute ~$11.64. Stays inside the default 8-vCPU regional
+# quota; no quota request needed.
+#
+# Usage (run on the maintainer's local box; the script SSHes to GCP):
+#
+#     bash scripts/build_wheel_gcp.sh                     # full run, tear down on success
+#     bash scripts/build_wheel_gcp.sh --keep-vm-on-error  # leave VM up if any build fails
+#     bash scripts/build_wheel_gcp.sh --resume-from blackwell-3.11
+#
+# Prerequisites on the local box:
+#   * gcloud CLI authenticated against tqcli-wheel-build
+#   * gsutil available
+#   * git remote `origin` -> github.com/tqcli/vllm-turboquant
+#
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# Configuration
+# ----------------------------------------------------------------------------
+PROJECT="${TQ_GCP_PROJECT:-tqcli-wheel-build}"
+ZONE="${TQ_GCP_ZONE:-us-central1-a}"
+VM_NAME="${TQ_VM_NAME:-vllm-tq-builder}"
+MACHINE="${TQ_MACHINE:-n2-standard-8}"
+DISK_SIZE_GB="${TQ_DISK_SIZE_GB:-200}"
+IMAGE_FAMILY="${TQ_IMAGE_FAMILY:-ubuntu-2204-lts}"
+IMAGE_PROJECT="${TQ_IMAGE_PROJECT:-ubuntu-os-cloud}"
+RELEASE_TAG="${TQ_RELEASE_TAG:-v0.7.0-tq1}"
+GCS_BUCKET="${TQ_GCS_BUCKET:-gs://tqcli-wheel-build}"
+GCS_PREFIX="${TQ_GCS_PREFIX:-0.7.0-tq1}"
+FORK_REPO="${TQ_FORK_REPO:-https://github.com/tqcli/vllm-turboquant.git}"
+
+KEEP_VM_ON_ERROR=0
+RESUME_FROM=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --keep-vm-on-error) KEEP_VM_ON_ERROR=1; shift ;;
+        --resume-from)      RESUME_FROM="$2"; shift 2 ;;
+        --help|-h)
+            sed -n "1,40p" "$0"
+            exit 0
+            ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER_SCRIPT="${SCRIPT_DIR}/_build_one_wheel.sh"
+[[ -f "${HELPER_SCRIPT}" ]] || { echo "missing helper: ${HELPER_SCRIPT}" >&2; exit 2; }
+
+# (flavour, py-version) sequence. Cheaper Ampere wheels first so a failure on
+# the Blackwell side does not waste compute earlier.
+BUILD_MATRIX=(
+    "ampere-ada-hopper:3.10"
+    "ampere-ada-hopper:3.11"
+    "ampere-ada-hopper:3.12"
+    "blackwell:3.10"
+    "blackwell:3.11"
+    "blackwell:3.12"
+)
+
+flavour_dist() {
+    case "$1" in
+        ampere-ada-hopper) echo "vllm-turboquant" ;;
+        blackwell)         echo "vllm-turboquant-blackwell" ;;
+        *) echo "" ;;
+    esac
+}
+flavour_archs() {
+    case "$1" in
+        ampere-ada-hopper) echo "8.0 8.6 8.9 9.0" ;;
+        blackwell)         echo "10.0 12.0 12.1+PTX" ;;
+        *) echo "" ;;
+    esac
+}
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+log() { printf "[build_wheel_gcp] %s\n" "$*" >&2; }
+die() { log "FATAL: $*"; exit 1; }
+
+teardown_vm() {
+    log "tearing down VM ${VM_NAME}"
+    gcloud compute instances delete "${VM_NAME}" \
+        --project="${PROJECT}" --zone="${ZONE}" --quiet || true
+}
+
+trap_handler() {
+    rc=$?
+    if [[ $rc -ne 0 && $KEEP_VM_ON_ERROR -eq 1 ]]; then
+        log "build failed (rc=$rc); leaving VM up per --keep-vm-on-error"
+        log "ssh: gcloud compute ssh ${VM_NAME} --project=${PROJECT} --zone=${ZONE}"
+        exit $rc
+    fi
+    teardown_vm
+    exit $rc
+}
+trap trap_handler EXIT
+
+remote() {
+    gcloud compute ssh "${VM_NAME}" \
+        --project="${PROJECT}" --zone="${ZONE}" \
+        --quiet --command="$1"
+}
+
+# ----------------------------------------------------------------------------
+# 1. Provision VM if missing
+# ----------------------------------------------------------------------------
+if gcloud compute instances describe "${VM_NAME}" \
+        --project="${PROJECT}" --zone="${ZONE}" --quiet >/dev/null 2>&1; then
+    log "VM ${VM_NAME} already exists; reusing"
+else
+    log "creating VM ${VM_NAME} (${MACHINE}, ${DISK_SIZE_GB}GB ${IMAGE_FAMILY})"
+    gcloud compute instances create "${VM_NAME}" \
+        --project="${PROJECT}" --zone="${ZONE}" \
+        --machine-type="${MACHINE}" \
+        --image-family="${IMAGE_FAMILY}" --image-project="${IMAGE_PROJECT}" \
+        --boot-disk-size="${DISK_SIZE_GB}GB" --boot-disk-type="pd-balanced" \
+        --scopes="https://www.googleapis.com/auth/devstorage.read_write,https://www.googleapis.com/auth/compute"
+    log "waiting up to 60s for SSH"
+    for _ in $(seq 1 12); do
+        if gcloud compute ssh "${VM_NAME}" --project="${PROJECT}" --zone="${ZONE}" \
+                --quiet --command="true" 2>/dev/null; then
+            break
+        fi
+        sleep 5
+    done
+fi
+
+# ----------------------------------------------------------------------------
+# 2. Bootstrap toolchain on VM (idempotent)
+# ----------------------------------------------------------------------------
+log "running bootstrap on VM (idempotent; no-op if already done)"
+remote 'set -e; if [[ -f $HOME/.tq-bootstrap-done ]]; then echo bootstrap-already-done; exit 0; fi
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    build-essential ccache git curl wget ninja-build \
+    software-properties-common ca-certificates gnupg
+sudo add-apt-repository -y ppa:deadsnakes/ppa
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    python3.10 python3.10-venv python3.10-dev \
+    python3.11 python3.11-venv python3.11-dev \
+    python3.12 python3.12-venv python3.12-dev
+wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+sudo dpkg -i cuda-keyring_1.1-1_all.deb
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cuda-toolkit-13-0
+sudo tee /etc/profile.d/cuda.sh >/dev/null <<EOPROFILE
+export PATH=/usr/local/cuda-13.0/bin:\$PATH
+export LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64:\${LD_LIBRARY_PATH:-}
+export CUDA_HOME=/usr/local/cuda-13.0
+EOPROFILE
+ccache -M 50G
+touch $HOME/.tq-bootstrap-done
+echo bootstrap-complete'
+
+# ----------------------------------------------------------------------------
+# 3. Sync fork checkout at the release tag
+# ----------------------------------------------------------------------------
+log "syncing fork checkout to ${RELEASE_TAG}"
+remote "set -e
+if [[ ! -d \$HOME/vllm-turboquant ]]; then git clone ${FORK_REPO} \$HOME/vllm-turboquant; fi
+cd \$HOME/vllm-turboquant
+git fetch --tags --force origin
+git checkout ${RELEASE_TAG}
+echo HEAD: \$(git rev-parse --short HEAD)"
+
+# ----------------------------------------------------------------------------
+# 4. Upload helper script
+# ----------------------------------------------------------------------------
+log "uploading helper script to VM"
+gcloud compute scp "${HELPER_SCRIPT}" \
+    "${VM_NAME}":~/_build_one_wheel.sh \
+    --project="${PROJECT}" --zone="${ZONE}" --quiet
+remote "chmod +x ~/_build_one_wheel.sh"
+
+# ----------------------------------------------------------------------------
+# 5. Build loop
+# ----------------------------------------------------------------------------
+SHOULD_RUN=1
+if [[ -n "${RESUME_FROM}" ]]; then SHOULD_RUN=0; fi
+
+for entry in "${BUILD_MATRIX[@]}"; do
+    flavour="${entry%%:*}"
+    pyver="${entry##*:}"
+    label="${flavour}-${pyver}"
+
+    if [[ "${SHOULD_RUN}" -eq 0 ]]; then
+        if [[ "${label}" == "${RESUME_FROM}" ]]; then
+            SHOULD_RUN=1
+        else
+            log "skipping ${label} (resume-from=${RESUME_FROM})"
+            continue
+        fi
+    fi
+
+    dist_name="$(flavour_dist "${flavour}")"
+    arch_list="$(flavour_archs "${flavour}")"
+    [[ -n "${dist_name}" ]] || die "unknown flavour ${flavour}"
+
+    log "BUILD ${label}: dist=${dist_name} archs='${arch_list}'"
+    remote "bash ~/_build_one_wheel.sh '${flavour}' '${pyver}' '${dist_name}' '${arch_list}' '${GCS_BUCKET}' '${GCS_PREFIX}'"
+    log "completed ${label}"
+done
+
+# ----------------------------------------------------------------------------
+# 6. Summary
+# ----------------------------------------------------------------------------
+log "all builds complete; listing GCS prefix"
+gsutil ls "${GCS_BUCKET}/${GCS_PREFIX}/" | tee /tmp/tq_wheel_manifest.txt
+
+count=$(grep -c '\.whl$' /tmp/tq_wheel_manifest.txt || echo 0)
+if [[ "${count}" -ne 6 ]]; then
+    die "expected 6 wheels in GCS, found ${count}"
+fi
+
+log "SUCCESS: 6 wheels at ${GCS_BUCKET}/${GCS_PREFIX}/"
+log "next: 'gsutil cp ${GCS_BUCKET}/${GCS_PREFIX}/* ./dist/' then 'gh release create ${RELEASE_TAG}' (see docs/RELEASING.md)"

--- a/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/verification_runpod.md
+++ b/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/verification_runpod.md
@@ -1,0 +1,178 @@
+# RunPod Verification — vllm-turboquant 0.7.0-tq1
+
+Workstream B step 11 + Section 3 cells V3, V4, V5. Total cost on RunPod
+Community Cloud (per 2026-04-26 GraphQL price check): ~$7.69. Account already
+validated (balance $500). The `runpodctl` CLI supports headless `pod create`,
+which is what we use here.
+
+The maintainer's `RUNPOD_API_KEY` lives outside the repo. Never commit it.
+
+## Cell V3 — RTX 4090 (sm_8.9, Ada) — `vllm-turboquant`
+
+```bash
+runpodctl create pods \
+    --name vllm-tq-v3-rtx4090 \
+    --imageName runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04 \
+    --gpuType "NVIDIA GeForce RTX 4090" \
+    --gpuCount 1 \
+    --secureCloud=false \
+    --containerDiskInGb 60 \
+    --communityCloud=true
+```
+
+Once the pod is running, `runpodctl exec` (or web SSH):
+
+```bash
+pip install vllm-turboquant \
+    --find-links https://github.com/tqcli/vllm-turboquant/releases/expanded_assets/v0.7.0-tq1
+python -c "
+import vllm
+from vllm.turboquant_arch_check import check_arch_compatibility
+print('TURBOQUANT_ENABLED:', vllm.TURBOQUANT_ENABLED)
+print('TURBOQUANT_BUILD_ARCH:', vllm.TURBOQUANT_BUILD_ARCH)
+print('TURBOQUANT_BUILD_ARCH_LIST:', vllm.TURBOQUANT_BUILD_ARCH_LIST)
+print('check_arch_compatibility():', check_arch_compatibility())
+"
+```
+
+**Pass criterion (V3):**
+- `TURBOQUANT_ENABLED: True`
+- `TURBOQUANT_BUILD_ARCH: ampere-ada-hopper`
+- `TURBOQUANT_BUILD_ARCH_LIST: 8.0 8.6 8.9 9.0`
+- `check_arch_compatibility(): None`
+
+End-to-end smoke (Gemma 4 E2B + turboquant35):
+
+```bash
+python -m vllm.entrypoints.openai.api_server \
+    --model google/gemma-2-2b-it \
+    --kv-cache-dtype turboquant35 \
+    --max-model-len 4096 &
+sleep 60
+curl -sS http://localhost:8000/v1/completions \
+    -H "Content-Type: application/json" \
+    -d '{"model":"google/gemma-2-2b-it","prompt":"Two plus two?","max_tokens":16}'
+```
+
+Expected wall time on RTX 4090: ~3 hours including pull + warmup. Cost ~$1.02.
+
+## Cell V4 — RTX 5090 (sm_12.0, Blackwell consumer) — `vllm-turboquant-blackwell`
+
+```bash
+runpodctl create pods \
+    --name vllm-tq-v4-rtx5090 \
+    --imageName runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04 \
+    --gpuType "NVIDIA GeForce RTX 5090" \
+    --gpuCount 1 \
+    --secureCloud=false \
+    --containerDiskInGb 60 \
+    --communityCloud=true
+```
+
+```bash
+pip install vllm-turboquant-blackwell \
+    --find-links https://github.com/tqcli/vllm-turboquant/releases/expanded_assets/v0.7.0-tq1
+python -c "
+import vllm
+print(vllm.TURBOQUANT_ENABLED, vllm.TURBOQUANT_BUILD_ARCH, vllm.TURBOQUANT_BUILD_ARCH_LIST)
+"
+```
+
+**Pass criterion (V4):**
+- `True ampere-ada-hopper` would be the wrong wheel (FAIL).
+- Required: `True blackwell 10.0 12.0 12.1+PTX`.
+
+Cross-flavour mismatch test (paste this on the same RTX 5090 pod after V4
+PASSes):
+
+```bash
+pip install --force-reinstall vllm-turboquant \
+    --find-links https://github.com/tqcli/vllm-turboquant/releases/expanded_assets/v0.7.0-tq1
+python -c "
+from vllm.turboquant_arch_check import assert_arch_compatibility
+try:
+    assert_arch_compatibility()
+except RuntimeError as e:
+    print('OK (raised as expected):', e)
+"
+```
+
+**Pass criterion (V4 mismatch):** `RuntimeError` is raised; the message
+contains `vllm-turboquant-blackwell` as the install hint.
+
+Expected wall time ~1 hour. Cost ~$0.69.
+
+## Cell V5 — B200 (sm_10.0, Blackwell DC) — `vllm-turboquant-blackwell`
+
+```bash
+runpodctl create pods \
+    --name vllm-tq-v5-b200 \
+    --imageName runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04 \
+    --gpuType "NVIDIA B200" \
+    --gpuCount 1 \
+    --secureCloud=false \
+    --containerDiskInGb 80 \
+    --communityCloud=true
+```
+
+Same install + assertion block as V4. Pass criterion: `blackwell` arch +
+`check_arch_compatibility()` returns `None` on sm_10.0.
+
+Expected wall time ~1 hour. Cost ~$5.98 (Community Cloud, 2026-04-26 price).
+
+## Cell V6 — GB10 (sm_12.1, DGX Spark) — own ASUS Ascent GX10
+
+RunPod does not stock GB10 as of 2026-04-26. Run on the maintainer's own
+ASUS Ascent GX10 (acquired 2026-04-25):
+
+```bash
+pip install vllm-turboquant-blackwell \
+    --find-links https://github.com/tqcli/vllm-turboquant/releases/expanded_assets/v0.7.0-tq1
+python -c "
+import torch, vllm
+from vllm.turboquant_arch_check import check_arch_compatibility
+print('cap:', torch.cuda.get_device_capability(0))
+print('TURBOQUANT_BUILD_ARCH:', vllm.TURBOQUANT_BUILD_ARCH)
+print('check:', check_arch_compatibility())
+"
+```
+
+Expected: `cap: (12, 1)`, `TURBOQUANT_BUILD_ARCH: blackwell`, `check: None`.
+This is the only path that exercises the `+PTX` JIT — sm_12.1 falls back to
+PTX from the sm_12.0 SASS unless the wheel embedded sm_12.1 SASS, which our
+arch list does (`12.1+PTX` includes both).
+
+Cost: $0 (own hardware).
+
+## Summary table
+
+| Cell | GPU                        | Cost       | Wall time | Assertion target               |
+|------|----------------------------|------------|-----------|--------------------------------|
+| V3   | RTX 4090                   | ~$1.02     | ~3 hrs    | ampere-ada-hopper PASS         |
+| V4   | RTX 5090                   | ~$0.69     | ~1 hr     | blackwell PASS + mismatch FAIL |
+| V5   | B200                       | ~$5.98     | ~1 hr     | blackwell PASS                 |
+| V6   | GB10 (own ASUS Ascent GX10)| $0         | ~1 hr     | blackwell+PTX PASS             |
+| **Total**                       | **~$7.69** | **~6 hrs** |                                |
+
+## After verification
+
+Edit `release_body.md` to fill in:
+- Per-wheel sizes (from `gsutil ls -l gs://tqcli-wheel-build/0.7.0-tq1/`)
+- The Verification table's `Result` column with PASS/FAIL
+- The actual build date
+
+Then post on the GitHub Release page (Edit -> paste body -> Save).
+
+## Cleanup
+
+```bash
+runpodctl stop pod vllm-tq-v3-rtx4090
+runpodctl stop pod vllm-tq-v4-rtx5090
+runpodctl stop pod vllm-tq-v5-b200
+runpodctl remove pod vllm-tq-v3-rtx4090
+runpodctl remove pod vllm-tq-v4-rtx5090
+runpodctl remove pod vllm-tq-v5-b200
+```
+
+Confirm RunPod balance after cleanup; we should have spent roughly $7.69
+out of the $500 balance.

--- a/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/vllm/__init__.py.snippet
+++ b/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/vllm/__init__.py.snippet
@@ -1,0 +1,16 @@
+# === TurboQuant fork sentinels (append to vllm/__init__.py) ===
+#
+# The build script (scripts/build_wheel_gcp.sh) rewrites the two BUILD_ARCH
+# fields below on each wheel build. Do NOT edit those values by hand — they are
+# populated per-flavor at build time so check_arch_compatibility() can distinguish
+# vllm-turboquant (Ampere/Ada/Hopper) wheels from vllm-turboquant-blackwell wheels
+# at runtime.
+#
+# Source-tree default (both empty strings) tells the runtime check to skip — that
+# is the right behaviour for editable installs of the source tree (no wheel was
+# built, so there is no built-arch claim to honour).
+
+TURBOQUANT_ENABLED = True
+TURBOQUANT_KV_DTYPES = ("turboquant25", "turboquant35")
+TURBOQUANT_BUILD_ARCH = ""        # "ampere-ada-hopper" or "blackwell" after build
+TURBOQUANT_BUILD_ARCH_LIST = ""   # literal TORCH_CUDA_ARCH_LIST value used at build

--- a/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/vllm/turboquant_arch_check.py
+++ b/patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/vllm/turboquant_arch_check.py
@@ -1,0 +1,109 @@
+"""Runtime arch-vs-build compatibility check for TurboQuant vLLM wheels.
+
+The 0.7.0 release ships two flavoured wheels:
+
+    vllm-turboquant            -> sm 8.0 / 8.6 / 8.9 / 9.0   (Ampere/Ada/Hopper)
+    vllm-turboquant-blackwell  -> sm 10.0 / 12.0 / 12.1+PTX (Blackwell DC, consumer, GB10)
+
+A user can install the wrong flavour for their GPU. This module hard-fails on
+the first GPU init with a clear remediation message instead of silently falling
+back, garbling kernels, or producing nonsense outputs.
+
+Wired in by ``vllm`` engine startup: callers should invoke
+``assert_arch_compatibility()`` once per process before launching the worker.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+
+_FLAVOR_ALT = {
+    "ampere-ada-hopper": "vllm-turboquant-blackwell",
+    "blackwell": "vllm-turboquant",
+}
+
+
+def _parse_arch_list(arch_list: str) -> List[Tuple[int, int]]:
+    """Parse a TORCH_CUDA_ARCH_LIST string into (major, minor) tuples.
+
+    Handles ``"8.0 8.6 8.9 9.0"`` and ``"10.0 12.0 12.1+PTX"``. The +PTX suffix
+    expresses forward-compat (PTX JIT) but does not change the compiled SASS
+    target, so we treat it as the same compute capability.
+    """
+    archs: List[Tuple[int, int]] = []
+    for token in arch_list.split():
+        token = token.strip().split("+", 1)[0]
+        if not token:
+            continue
+        try:
+            major_str, minor_str = token.split(".")
+            archs.append((int(major_str), int(minor_str)))
+        except (ValueError, IndexError):
+            # Skip malformed tokens; build script controls this string.
+            continue
+    return archs
+
+
+def _detected_capability() -> Optional[Tuple[Tuple[int, int], str]]:
+    """Return ((major, minor), device_name) for cuda:0, or None if unavailable."""
+    try:
+        import torch  # local import: keep this module importable on CPU-only boxes
+    except ImportError:
+        return None
+    if not torch.cuda.is_available():
+        return None
+    cap = torch.cuda.get_device_capability(0)
+    name = torch.cuda.get_device_name(0)
+    return (int(cap[0]), int(cap[1])), name
+
+
+def check_arch_compatibility() -> Optional[str]:
+    """Return a remediation message if the wheel/runtime arches mismatch, else None.
+
+    Returns ``None`` when:
+      * No CUDA GPU is visible (CPU-only smoke tests, container without --gpus).
+      * The build sentinels are empty (editable source install — no wheel claim).
+      * The detected GPU's compute capability is in the build's arch list.
+    """
+    cap_info = _detected_capability()
+    if cap_info is None:
+        return None
+    capability, device_name = cap_info
+
+    try:
+        from vllm import TURBOQUANT_BUILD_ARCH, TURBOQUANT_BUILD_ARCH_LIST
+    except ImportError:
+        return None
+
+    if not TURBOQUANT_BUILD_ARCH or not TURBOQUANT_BUILD_ARCH_LIST:
+        # Editable / source build with no wheel-time arch claim. Skip.
+        return None
+
+    built_archs = _parse_arch_list(TURBOQUANT_BUILD_ARCH_LIST)
+    if not built_archs:
+        return None
+    if capability in built_archs:
+        return None
+
+    built_str = " / ".join(f"sm_{m}.{n}" for m, n in built_archs)
+    detected_str = f"sm_{capability[0]}.{capability[1]}"
+    recommend = _FLAVOR_ALT.get(TURBOQUANT_BUILD_ARCH, "the matching vllm-turboquant flavour")
+
+    return (
+        f"This wheel was built for {TURBOQUANT_BUILD_ARCH} GPUs ({built_str}). "
+        f"Detected your GPU as {detected_str} ({device_name}). "
+        f"Install `{recommend}` instead. "
+        f"See https://github.com/tqcli/vllm-turboquant#install for the GPU-flavour table."
+    )
+
+
+def assert_arch_compatibility() -> None:
+    """Raise ``RuntimeError`` if the wheel/runtime arches mismatch.
+
+    Idempotent and cheap — designed to be called from engine startup. No-op when
+    no GPU is visible or when running from an editable source tree.
+    """
+    msg = check_arch_compatibility()
+    if msg is not None:
+        raise RuntimeError(msg)


### PR DESCRIPTION
## Summary

**Status: ARCHIVE / STAGED — DO NOT MERGE. Apply to fork instead.**

Workstream B artifacts produced by the 2026-04-26 \`/project-manager\` worker-2 run. Authoring complete; cross-repo application + GCP build deferred to maintainer per Option-3 cohesive-launch decision (held until Workstream A is also resolved).

## What's in this branch

\`patches/vllm-turboquant/wheel_distribution_v0.7.0-tq1/\`:
- \`vllm/__init__.py.snippet\` — sentinels for the fork (\`TURBOQUANT_ENABLED\`, \`TURBOQUANT_KV_DTYPES\`, two BUILD_ARCH fields populated at build time)
- \`vllm/turboquant_arch_check.py\` — runtime check; \`assert_arch_compatibility()\` raises \`RuntimeError\` on wheel/GPU mismatch with remediation pip command (parser unit-tested)
- \`scripts/build_wheel_gcp.sh\` + \`scripts/_build_one_wheel.sh\` — sequential six-wheel GCP build (n2-standard-8, ~30h, ~\$12); supports \`--keep-vm-on-error\` and \`--resume-from\`; both pass \`bash -n\`
- \`fork_changes.md\` — pyproject.toml templated-name protocol, README install table, golden-commit pinning instructions
- \`docs/RELEASING.md\` — maintainer runbook (tag → build → 2 GiB size gate → release cut → rollback → cost ledger)
- \`release_body.md\` — GitHub Release body template
- \`verification_runpod.md\` — V3 RTX 4090, V4 RTX 5090 (with cross-flavor mismatch test), V5 B200, V6 GB10 commands

## Deferred to maintainer

- Identifying golden commit SHA on the fork's \`main\` branch (post Issue #22 four-patch fix)
- Applying the staged files to \`github.com/tqcli/vllm-turboquant\`
- Tagging \`v0.7.0-tq1\`
- Running the GCP build (~30h, ~\$12)
- Creating GitHub Release + uploading 6 wheels
- V3/V4/V5 RunPod verification

## Disposition

This PR should be **closed without merge** once \`tq-cross-repo-prep\` (issue #35) drives application of these artifacts to the actual \`tqcli/vllm-turboquant\` fork. Keeping this PR open serves as the design archive until the fork prep lands.